### PR TITLE
chore: support for nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ resource "cloudamqp_instance" "default" {
   plan        = var.plan
   region      = "amazon-web-services::${var.region}"
   rmq_version = var.rmq_version
+  nodes       = var.nodes
 }
 
 resource "cloudamqp_notification" "email" {
@@ -20,7 +21,9 @@ resource "cloudamqp_notification" "slack" {
 }
 
 locals {
-  recipients = flatten([[for i, v in cloudamqp_notification.email : v.id], [for i, v in cloudamqp_notification.slack : v.id]])
+  recipients = flatten([
+    [for i, v in cloudamqp_notification.email : v.id], [for i, v in cloudamqp_notification.slack : v.id]
+  ])
 }
 
 resource "cloudamqp_alarm" "consumer_alarm" {

--- a/vars.tf
+++ b/vars.tf
@@ -8,6 +8,12 @@ variable "plan" {
   description = "Plan for instance"
 }
 
+variable "nodes" {
+  type        = number
+  default     = null
+  description = "Number of instances for plan. *Deprecated* see https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/instance#nodes"
+}
+
 variable "region" {
   type        = string
   description = "Region where instance will be located"


### PR DESCRIPTION
This is a bug in the cloud amqp provider for free plans.
If using lemur you must supply nodes = 1 for example