### PR TITLE
feat: make time threshold for consumer configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "cloudamqp_alarm" "consumer_alarm" {
   instance_id     = cloudamqp_instance.default.id
   type            = "consumer"
   enabled         = true
-  time_threshold  = 60
+  time_threshold  = var.consumer_alarm_time_threshold
   value_threshold = 0
   recipients      = local.recipients
   queue_regex     = var.consumer_alarm_queue_regex

--- a/vars.tf
+++ b/vars.tf
@@ -78,3 +78,9 @@ variable "disk_alarm_threshold" {
   description = "Threshold for disk alarm. Only for dedicated instances. If no value is provided, no alarm will be setup"
   default     = null
 }
+
+variable "consumer_alarm_time_threshold" {
+  type        = number
+  description = "Time in seconds for consumer alarm, default to 60 secs."
+  default     = 60
+}


### PR DESCRIPTION
- consumer_alarm_time_threshold can be used to configure time threshold for missing consumers.
- default to 60 secs.