### PR TITLE
chore: update Terraform required version to 1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        tf-version: [ 1.1.9, 1.2.9, 1.3.2 ]
+        tf-version: [ 1.3.2 ]
     steps:
       - name: Install terraform v${{ matrix.tf-version }}
         run: |

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -28,5 +28,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update the required Terraform version from 1.1.9 to 1.3 in both 
provider.tf and providers.tf files to ensure compatibility with 
the latest features and improvements in Terraform.