### PR TITLE
feat!: switch notification recipient vars to map(string) and always set name

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -5,5 +5,5 @@ module "rabbitmq" {
   secret_name    = "cloudamqp"
   plan           = "lemur"
   nodes          = 1
-  teams_webhooks = []
+  teams_webhooks = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -8,23 +8,26 @@ resource "cloudamqp_instance" "default" {
 }
 
 resource "cloudamqp_notification" "email" {
-  for_each    = toset(var.email_recipients)
+  for_each    = var.email_recipients
   instance_id = cloudamqp_instance.default.id
   type        = "email"
+  name        = each.key
   value       = each.value
 }
 
 resource "cloudamqp_notification" "slack" {
-  for_each    = toset(var.slack_webhooks)
+  for_each    = var.slack_webhooks
   instance_id = cloudamqp_instance.default.id
   type        = "slack"
+  name        = each.key
   value       = each.value
 }
 
 resource "cloudamqp_notification" "teams" {
-  for_each    = toset(var.teams_webhooks)
+  for_each    = var.teams_webhooks
   instance_id = cloudamqp_instance.default.id
   type        = "teams"
+  name        = each.key
   value       = each.value
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -32,21 +32,21 @@ variable "rmq_version" {
 }
 
 variable "email_recipients" {
-  type        = list(string)
-  description = "List of email recipients for alerts"
-  default     = []
+  type        = map(string)
+  description = "Map of email recipients for alerts. Key is the recipient name shown in the cloudamqp UI, value is the email address."
+  default     = {}
 }
 
 variable "slack_webhooks" {
-  type        = list(string)
-  description = "List of Slack webhooks which will be called for alerts"
-  default     = []
+  type        = map(string)
+  description = "Map of Slack webhooks called for alerts. Key is the recipient name shown in the cloudamqp UI, value is the webhook URL."
+  default     = {}
 }
 
 variable "teams_webhooks" {
-  type        = list(string)
-  description = "List of Teams webhooks which will be called for alerts"
-  default     = []
+  type        = map(string)
+  description = "Map of Teams webhooks called for alerts. Key is the recipient name shown in the cloudamqp UI, value is the webhook URL."
+  default     = {}
 }
 
 variable "consumer_alarm_queue_regex" {


### PR DESCRIPTION
## Why

The cloudamqp provider (since `v1.43.0`) panics with a nil pointer deref in `ReadNotification` when the recipient `name` is `null` in the API response:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2]

github.com/cloudamqp/terraform-provider-cloudamqp/api.(*API).ReadNotification(...)
    api/notifications.go:55 +0x33c
github.com/cloudamqp/terraform-provider-cloudamqp/cloudamqp.(*notificationResource).Read(...)
    cloudamqp/resource_cloudamqp_notification.go:224 +0x184
```

The notification resources in this module never set `name`, so every email/slack/teams recipient created by it is stored with `name=null` on the cloudamqp side and triggers the panic on the next `terraform plan`/`refresh`.

Root cause is a chain of three upstream bugs:

- `RecipientResponse.Name` is typed `string`; `null` from the API breaks JSON decode.
- `callWithRetry` swallows the `sling.Receive` decode error.
- `ReadNotification` calls `data.Sanitized()` before the nil-check.

Until upstream lands a fix, the module must stop creating null-named recipients in the first place.

## What changed

- `email_recipients`, `slack_webhooks`, `teams_webhooks` go from `list(string)` to `map(string)`.
- The map key is set as the recipient `name` shown in the cloudamqp UI; the map value remains the email address / webhook URL.
- `examples/basic` updated.

## ⚠️ Breaking

Callers must convert lists to maps:

```hcl
# before
email_recipients = ["peter@example.com"]
slack_webhooks   = ["https://hooks.slack.com/services/..."]
teams_webhooks   = []

# after
email_recipients = { "peter" = "peter@example.com" }
slack_webhooks   = { "platform" = "https://hooks.slack.com/services/..." }
teams_webhooks   = {}
```

The map key becomes the `cloudamqp_notification.name` attribute. Existing recipients see a one-time plan diff updating `name` from `null` to the chosen key on apply; no recipient recreation.

release-please will publish this as `v0.2.0` thanks to the `feat!:` commit prefix and `BREAKING CHANGE:` footer.
